### PR TITLE
Set Secure Processing flag on DocumentBuilderFactory

### DIFF
--- a/src/mapper/java/org/codehaus/jackson/map/ext/DOMDeserializer.java
+++ b/src/mapper/java/org/codehaus/jackson/map/ext/DOMDeserializer.java
@@ -2,7 +2,9 @@ package org.codehaus.jackson.map.ext;
 
 import java.io.StringReader;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.deser.std.FromStringDeserializer;
@@ -22,6 +24,11 @@ public abstract class DOMDeserializer<T> extends FromStringDeserializer<T>
         _parserFactory = DocumentBuilderFactory.newInstance();
         // yup, only cave men do XML without recognizing namespaces...
         _parserFactory.setNamespaceAware(true);
+        try {
+            _parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch(ParserConfigurationException pce) {
+            System.err.println("[DOMDeserializer] Problem setting SECURE_PROCESSING_FEATURE: " + pce.toString());
+        }
     }
 
     protected DOMDeserializer(Class<T> cls) { super(cls); }

--- a/src/mapper/java/org/codehaus/jackson/map/ext/DOMDeserializer.java
+++ b/src/mapper/java/org/codehaus/jackson/map/ext/DOMDeserializer.java
@@ -24,6 +24,7 @@ public abstract class DOMDeserializer<T> extends FromStringDeserializer<T>
         _parserFactory = DocumentBuilderFactory.newInstance();
         // yup, only cave men do XML without recognizing namespaces...
         _parserFactory.setNamespaceAware(true);
+        _parserFactory.setExpandEntityReferences(false);
         try {
             _parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         } catch(ParserConfigurationException pce) {

--- a/src/xc/java/org/codehaus/jackson/xc/DomElementJsonDeserializer.java
+++ b/src/xc/java/org/codehaus/jackson/xc/DomElementJsonDeserializer.java
@@ -30,6 +30,7 @@ public class DomElementJsonDeserializer
         try {
             DocumentBuilderFactory bf = DocumentBuilderFactory.newInstance();
             bf.setNamespaceAware(true);
+            bf.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
             builder = bf.newDocumentBuilder();
         } catch (ParserConfigurationException e) {
             throw new RuntimeException();

--- a/src/xc/java/org/codehaus/jackson/xc/DomElementJsonDeserializer.java
+++ b/src/xc/java/org/codehaus/jackson/xc/DomElementJsonDeserializer.java
@@ -30,10 +30,11 @@ public class DomElementJsonDeserializer
         try {
             DocumentBuilderFactory bf = DocumentBuilderFactory.newInstance();
             bf.setNamespaceAware(true);
+            bf.setExpandEntityReferences(false);
             bf.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
             builder = bf.newDocumentBuilder();
         } catch (ParserConfigurationException e) {
-            throw new RuntimeException();
+            throw new RuntimeException("Problem creating DocumentBuilder: " + e.toString());
         }
     }
 


### PR DESCRIPTION
Based on http://stackoverflow.com/questions/38017676/small-fix-for-cve-2016-3720-with-older-versions-of-jackson-all-1-9-11-and-in-ja
If it is feasible to get a 1.9.14 patch built, I can look to add some unit test coverage.
