### PR TITLE
fix build-osgi class paths

### DIFF
--- a/ant/build-osgi.xml
+++ b/ant/build-osgi.xml
@@ -86,7 +86,7 @@ org.codehaus.jackson.io;version='${IMPL_VERSION}',
 org.codehaus.jackson.type;version='${IMPL_VERSION}',
 org.codehaus.jackson.util;version='${IMPL_VERSION}',
 org.xml.sax,org.w3c.dom,
-javax.xml.datatype, javax.xml.namespace, javax.xml.parsers
+javax.xml, javax.xml.datatype, javax.xml.namespace, javax.xml.parsers
 "
          dynamicImportPackage="
 org.joda.time, org.joda.time.format,
@@ -187,7 +187,7 @@ org.codehaus.jackson.io;version='${IMPL_VERSION}',
 org.codehaus.jackson.type;version='${IMPL_VERSION}',
 org.codehaus.jackson.util;version='${IMPL_VERSION}',
 org.xml.sax, org.w3c.dom,
-javax.xml.datatype, javax.xml.namespace, javax.xml.parsers
+javax.xml, javax.xml.datatype, javax.xml.namespace, javax.xml.parsers
 "
          dynamicImportPackage="
 org.joda.time, org.joda.time.format,
@@ -350,7 +350,7 @@ javax.activation
 ,org.codehaus.jackson.util;version='${IMPL_VERSION}'
 "
          dynamicImportPackage="org.w3c.dom
-,javax.xml.namespace, javax.xml.parsers, javax.xml.transform
+, javax.xml, javax.xml.namespace, javax.xml.parsers, javax.xml.transform
 "
          exportPackage="
 org.codehaus.jackson.xc;version='${IMPL_VERSION}'


### PR DESCRIPTION
I didn't run 'ant dist' before and these classpath entries need to be updated to the recent source changes
