### PR TITLE
Backport writeRawValue surrogate pair fix from 2.x

### DIFF
--- a/src/java/org/codehaus/jackson/impl/Utf8Generator.java
+++ b/src/java/org/codehaus/jackson/impl/Utf8Generator.java
@@ -754,7 +754,7 @@ public class Utf8Generator
                 _outputBuffer[_outputTail++] = (byte) (0xc0 | (ch >> 6));
                 _outputBuffer[_outputTail++] = (byte) (0x80 | (ch & 0x3f));
             } else {
-                _outputRawMultiByteChar(ch, cbuf, offset, len);
+                offset = _outputRawMultiByteChar(ch, cbuf, offset, len);
             }
         }
     }
@@ -812,7 +812,7 @@ public class Utf8Generator
                 bbuf[_outputTail++] = (byte) (0xc0 | (ch >> 6));
                 bbuf[_outputTail++] = (byte) (0x80 | (ch & 0x3f));
             } else {
-                _outputRawMultiByteChar(ch, cbuf, offset, len);
+                offset = _outputRawMultiByteChar(ch, cbuf, offset, len);
             }
         }
     }
@@ -1643,7 +1643,7 @@ public class Utf8Generator
         if (ch >= SURR1_FIRST) {
             if (ch <= SURR2_LAST) { // yes, outside of BMP
                 // Do we have second part?
-                if (inputOffset >= inputLen) { // nope... have to note down
+                if (inputOffset >= inputLen || cbuf == null) { // nope... have to note down
                     _reportError("Split surrogate on writeRaw() input (last character)");
                 }
                 _outputSurrogates(ch, cbuf[inputOffset]);


### PR DESCRIPTION
This is a backport of a Jackson 2.x fix:
https://github.com/FasterXML/jackson-core/commit/5e14c461c04f71fc3f35a5ac2e75ed2df0d7c462
